### PR TITLE
issue-5: resolved issue where repo link didn't work after name change

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html class="no-js" lang="">
+<html class="no-js" lang="en">
 
 <head>
   <meta charset="utf-8">
-  <title>Training Timer</title>
+  <title>Training Tool</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -65,7 +65,7 @@
     </a>
   </p>
   <p class="footer__item">
-    <a href="https://github.com/DTHutton/training-timer" target="_blank">
+    <a href="https://github.com/DTHutton/remote-training-tool" target="_blank">
       Repo
     </a>
   </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "training_timer",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Repo link was broken on home page after name change. Changed link to updated version: https://github.com/DTHutton/remote-training-tool